### PR TITLE
Update FMS-100 ( Save API for fixed and Bidding Indent)

### DIFF
--- a/src/main/java/com/sqltest/demo/controller/indentController.java
+++ b/src/main/java/com/sqltest/demo/controller/indentController.java
@@ -1,4 +1,23 @@
 package com.sqltest.demo.controller;
 
-public class indentController {
+import com.sqltest.demo.model.SubscribedIndents;
+import com.sqltest.demo.service.saveIndentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/indents")
+public class indentController{
+
+    @Autowired
+    private saveIndentService service;
+    @PostMapping("/saveIndent")
+    public ResponseEntity<?> createSubscribedIndent(@RequestBody SubscribedIndents indent) {
+        return service.saveSubscribedIndent(indent);
+    }
+
 }

--- a/src/main/java/com/sqltest/demo/model/SalesOrder.java
+++ b/src/main/java/com/sqltest/demo/model/SalesOrder.java
@@ -65,4 +65,6 @@ public class SalesOrder {
 
     @Column(name = "dispatch_details", length = 2000)
     private String dispatchDetails;
+
+    private boolean subscribed = false;
 }

--- a/src/main/java/com/sqltest/demo/model/SubscribedIndents.java
+++ b/src/main/java/com/sqltest/demo/model/SubscribedIndents.java
@@ -1,0 +1,28 @@
+package com.sqltest.demo.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Entity
+@Table(name = "Subscribed_Indents")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubscribedIndents{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "so_id", referencedColumnName = "soId")
+    private SalesOrder salesOrder;
+
+    private List<String> route;
+    private Integer biddingPrice;
+}

--- a/src/main/java/com/sqltest/demo/repository/SubscribedIndentRepository.java
+++ b/src/main/java/com/sqltest/demo/repository/SubscribedIndentRepository.java
@@ -1,0 +1,8 @@
+package com.sqltest.demo.repository;
+
+import com.sqltest.demo.model.SubscribedIndents;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscribedIndentRepository extends JpaRepository<SubscribedIndents, Long> {
+    boolean existsBySalesOrder_SoId(Long soId);
+}

--- a/src/main/java/com/sqltest/demo/service/saveIndentService.java
+++ b/src/main/java/com/sqltest/demo/service/saveIndentService.java
@@ -1,0 +1,57 @@
+package com.sqltest.demo.service;
+
+import com.sqltest.demo.model.SalesOrder;
+import com.sqltest.demo.model.SubscribedIndents;
+import com.sqltest.demo.repository.SalesOrderRepo;
+import com.sqltest.demo.repository.SubscribedIndentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class saveIndentService {
+
+    private static final Logger logger = LoggerFactory.getLogger(saveIndentService.class);
+
+    @Autowired
+    private SubscribedIndentRepository subscribedIndentRepository;
+
+    @Autowired
+    private SalesOrderRepo salesOrderRepository;
+
+    @Transactional
+    public ResponseEntity<?> saveSubscribedIndent(SubscribedIndents indent) {
+        Long soId = Long.valueOf(indent.getSalesOrder().getSoId());
+
+        if (subscribedIndentRepository.existsBySalesOrder_SoId(soId)) {
+            logger.warn("Duplicate SO_ID: " + soId + " - Entry not saved.");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Duplicate SO_ID: " + soId + " - Entry not saved.");
+        }
+
+        if (!salesOrderRepository.existsById(soId)) {
+            logger.warn("Invalid SO_ID: " + soId + " - Entry not saved.");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Invalid SO_ID: " + soId + " - Entry not saved.");
+        }
+
+        SubscribedIndents savedIndent = subscribedIndentRepository.save(indent);
+
+        // Update the subscribed flag in SalesOrder
+        SalesOrder salesOrder = salesOrderRepository.findById(soId).orElse(null);
+        if (salesOrder != null) {
+            salesOrder.setSubscribed(true); // Set subscribed to true
+            salesOrderRepository.save(salesOrder); // Update the SalesOrder entity
+            logger.info("Updated subscribed flag for SO_ID: " + soId);
+        } else {
+            logger.warn("SalesOrder with SO_ID " + soId + " not found.");
+            // Handle error if SalesOrder is not found
+            // You may decide to roll back the SubscribedIndent entry here
+        }
+        return ResponseEntity.ok(savedIndent);
+    }
+}


### PR DESCRIPTION
**Post Mapping:  “/api/indents/saveIndent”**

Once the Schede trip or Place button is clicked(In the indent details page) a Post request with the following details will hit:

- For fixed Indents:

  - Save the following information to the Subscribed Indents Table:
  
    - SO information
    
    - Route Information ( Chosen by the Transport manager).
    
  - Mark the Subscribed Indent from the SO table as Subscribed. (Since it must not be visible in New Indents)

- For Bidding Indents:

  - Save the following information to the Subscribed Indents Table:
  
    - SO information
    
    - Bid chosen amount
    
    - Route Information
  
  - Mark the Subscribed Indent from the SO table as Subscribed.